### PR TITLE
license -> licence

### DIFF
--- a/GFYCLA
+++ b/GFYCLA
@@ -17,16 +17,16 @@ SECTION 1 – DEFINITIONS.
      acknowledge, the phrase "Go fuck yourself." You are able to 
      respond to the listed phrase using any observable means, 
      mentally acknowledging the phrase is permitted only if you 
-     (The LICENSEE) are within 3 meters of 2 or more persons in 
+     (The LICENCEE) are within 3 meters of 2 or more persons in 
      a physical area.
-  b. LICENSEE means the individual or entity exercising the 
-     Licensed Rights under this License. YOU has a corresponding meaning.
-  c. LICENSOR means the individual(s) or entity(ies) granting rights 
-     under this License. OWNER has a corresponding meaning
+  b. LICENCEE means the individual or entity exercising the 
+     Licenced Rights under this Licence. YOU has a corresponding meaning.
+  c. LICENCOR means the individual(s) or entity(ies) granting rights 
+     under this Licence. OWNER has a corresponding meaning
   d. LICENCED MATERIAL means the artistic or literary work, database, 
-     or other material to which the Licensor applied this License.
+     or other material to which the Licencor applied this Licence.
   e. CONTRIBUTION means any artistic or literary work, database, or other
-     material that a person or entity other than the Licensor has created
+     material that a person or entity other than the Licencor has created
      to be used in the Licenced Material
   f. CONTRIBUTOR means a person or entity that has created a Contribution
 
@@ -35,12 +35,12 @@ SECTION 2 - Licence Agreement Condition
   a. USAGE
             1. By creating a Contribution, you, the Contributor, are 
                agreeing to give all rights of your Contribution to the 
-               Licensor.
+               Licencor.
                      i. By creating a Contribution, you are obligated to
                         give a response satisfying the terms in 1(a).
                      ii. Any and all Contributions will automatically be
-                         considered Licensed Material and is fully owned
-                         by the Licensor.
+                         considered Licenced Material and is fully owned
+                         by the Licencor.
 
   b. TERMS            
             1. Being a Contributor does not exempt you from any of the 

--- a/GFYPL
+++ b/GFYPL
@@ -18,14 +18,14 @@ SECTION 1 – DEFINITIONS.
     acknowledge, the phrase "Go fuck yourself." You are able to
     respond to the listed phrase using any observable means,
     mentally acknowledging the phrase is permitted only if you
-    (The LICENSEE) are within 3 meters of 2 or more persons in
+    (The LICENCEE) are within 3 meters of 2 or more persons in
     a physical area.
- b. LICENSEE means the individual or entity exercising the
-    Licensed Rights under this License. YOU has a corresponding meaning.
- c. LICENSOR means the individual(s) or entity(ies) granting rights
-    under this License. OWNER has a corresponding meaning
+ b. LICENCEE means the individual or entity exercising the
+    Licenced Rights under this Licence. YOU has a corresponding meaning.
+ c. LICENCOR means the individual(s) or entity(ies) granting rights
+    under this Licence. OWNER has a corresponding meaning
  d. LICENCED MATERIAL means the artistic or literary work, database,
-    or other material to which the Licensor applied this License.
+    or other material to which the Licencor applied this Licence.
 
 SECTION 2 - Licence Condition
 
@@ -61,7 +61,7 @@ SECTION 2 - Licence Condition
                     i. attempting to recreate the exact functions
                        means you are obligated to give a response
                        satisfying the terms in 1(a).
-           5. It is requested by the Licensor that you do not view this licence
+           5. It is requested by the Licencor that you do not view this licence
                     i. viewing this licence means you are obligated
                        to give a response satisfying the terms
                        in 1(a).


### PR DESCRIPTION
Technically closes #15 as the usage is now consistent.